### PR TITLE
Rewrite to be multi-phase, support custom topics/topic generator, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .seed
 output
 topics.txt
+*.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ venv/
 __pycache__
 .seed
 output
-topics.txt
+topics*.txt
 *.jsonl

--- a/README.md
+++ b/README.md
@@ -16,22 +16,6 @@ This updated implementation supports either the /v1/completions endpoint or /v1/
 * generally speaking, this implementation tries to reduce some of the [noise](https://github.com/tloen/alpaca-lora/issues/65)
 
 
-## Initial datasets
-
-Be sure to look over the openai terms of service before using the datasets, specifically the section about using the outputs to generate competing models...
-
-### 100k synthetic instructions, gpt-3.5-turbo
-
-* [instructions.jsonl](https://storage.googleapis.com/airoboros-dump/gpt-3.5-turbo-100k/instructions.jsonl)
-* [topics.txt](https://storage.googleapis.com/airoboros-dump/gpt-3.5-turbo-100k/topics.txt)
-
-
-### 40k synthetic instructions, gpt-4
-
-* [instructions.json](https://storage.googleapis.com/airoboros-dump/gpt-4-40k/instructions.jsonl)
-* [topics.txt](https://storage.googleapis.com/airoboros-dump/gpt-4-40k/topics.txt)
-
-
 ## Generating instructions
 
 See available options via:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # airoboros: using large language models to fine-tune large language models
 
-This is my take on implementing the [Self-Instruct paper](https://arxiv.org/abs/2212.10560).  The approach is quite heavily modified, and uses the human generated seeds provided by [Databricks Dolly Project](https://huggingface.co/datasets/databricks/databricks-dolly-15k)
+This is my take on implementing the [Self-Instruct paper](https://arxiv.org/abs/2212.10560).  The approach is quite heavily modified, and does not use any human-generated seeds.
 
 This updated implementation supports either the /v1/completions endpoint or /v1/chat/completions, which is particularly useful in that it supports gpt-4 and gpt-3.5-turbo (which is 1/10 the cost of text-davinci-003).
 
 
 ## Key differences
 
-* Sample instructions in prompts by default use the human-generated seeds from Dolly.
-* Machine-generated instructions are not sampled for prompt examples, to avoid degredation.
-* Support for either /v1/completions or /v1/chat/completions APIs (which allows gpt-3.5-turbo instead of text-davinci-003, as well as gpt-4 if you have access).
-* In memory vector db (Chroma) for similarity comparison, which is much faster than calculating rouge score for each generated instruction.
-* (Seemingly) better prompt, which includes injection of random topics to relate the instructions to, which creates much more diverse prompts.
-* Multi-threaded producers/consumer implementation for significantly faster runtimes (generally 150+ unique prompts per minute, more initially since there are fewer duplicates, decreasing over time).
-* Tries to ensure the context, if provided, is relevant to the topic and contains all the information that would be necessary to respond to the instruction, and nost just a link to article/etc.
-* Generally speaking, this implementation tries to reduce some of the [noise](https://github.com/tloen/alpaca-lora/issues/65)
+* support for either /v1/completions or /v1/chat/completions APIs (which allows gpt-3.5-turbo instead of text-davinci-003, as well as gpt-4 if you have access)
+* support for custom topics list, custom topic generation prompt, or completely random topics
+* sn memory vector db (Chroma) for similarity comparison, which is much faster than calculating rouge score for each generated instruction
+* (seemingly) better prompts, which includes injection of random topics to relate the instructions to, which creates much more diverse synthetic instructions
+* multi-threaded producer/consumer implementation for significantly faster runtimes (generally 150+ unique prompts per minute, more initially since there are fewer duplicates, decreasing over time).
+* tries to ensure the context, if provided, is relevant to the topic and contains all the information that would be necessary to respond to the instruction, and nost just a link to article/etc.
+* generally speaking, this implementation tries to reduce some of the [noise](https://github.com/tloen/alpaca-lora/issues/65)
 
 
 ## Initial datasets
@@ -40,11 +39,11 @@ See available options via:
 airoboros generate-instructions --help
 ```
 
-Example output:
+Help as of 2023-05-10:
 ```
-usage: self_instruct.py [-h] [--model MODEL] [--organization-id ORGANIZATION_ID] [--openai-api-key OPENAI_API_KEY] [--instruction-count INSTRUCTION_COUNT] [--seed-tasks-path SEED_TASKS_PATH] [--output-path OUTPUT_PATH] [--overwrite] [--append] [--prompt PROMPT] [--skip-instruction-re SKIP_INSTRUCTION_RE] [--code-gen-re CODE_GEN_RE]
-                        [--samples-per-request SAMPLES_PER_REQUEST] [--min-instruction-length MIN_INSTRUCTION_LENGTH] [--max-instruction-length MAX_INSTRUCTION_LENGTH] [--temperature TEMPERATURE] [--top-p TOP_P] [--frequency-penalty FREQUENCY_PENALTY] [--presence-penalty PRESENCE_PENALTY] [--max-usage-tokens MAX_USAGE_TOKENS]
-                        [--prompt-generation-concurrency PROMPT_GENERATION_CONCURRENCY] [--min-docsearch-score MIN_DOCSEARCH_SCORE]
+usage: self_instruct.py [-h] [--model MODEL] [--organization-id ORGANIZATION_ID] [--openai-api-key OPENAI_API_KEY] [--instruction-count INSTRUCTION_COUNT] [--batch-size BATCH_SIZE] [--output-path OUTPUT_PATH] [--topics-path TOPICS_PATH] [--overwrite] [--append] [--prompt PROMPT] [--contextual-prompt CONTEXTUAL_PROMPT]
+                        [--topic-generation-prompt TOPIC_GENERATION_PROMPT] [--topic-request-count TOPIC_REQUEST_COUNT] [--contextual-prompt-ratio CONTEXTUAL_PROMPT_RATIO] [--skip-instruction-re SKIP_INSTRUCTION_RE] [--temperature TEMPERATURE] [--top-p TOP_P] [--frequency-penalty FREQUENCY_PENALTY] [--presence-penalty PRESENCE_PENALTY]
+                        [--max-usage-tokens MAX_USAGE_TOKENS] [--concurrency CONCURRENCY] [--min-docsearch-score MIN_DOCSEARCH_SCORE]
 
 options:
   -h, --help            show this help message and exit
@@ -55,23 +54,25 @@ options:
                         OpenAI API key to use, defaults to the OPENAI_API_KEY environment variable
   --instruction-count INSTRUCTION_COUNT
                         number of instructions to generate, not including the seed instructions
-  --seed-tasks-path SEED_TASKS_PATH
-                        path to an input seed instructions JSONL file
+  --batch-size BATCH_SIZE
+                        number of candidate instructions to (attempt to) generate per request
   --output-path OUTPUT_PATH
                         path to store all generated instructions in
+  --topics-path TOPICS_PATH
+                        path to a newline separated list of topics
   --overwrite           overwrite output path if it exists
   --append              append to output path if it exists
-  --prompt PROMPT       prompt prefix to use for generating tasks
+  --prompt PROMPT       prompt prefix to use for generating non-contextual instructions
+  --contextual-prompt CONTEXTUAL_PROMPT
+                        prompt to use for generating contextual prompts
+  --topic-generation-prompt TOPIC_GENERATION_PROMPT
+                        prompt to use in generating random topics
+  --topic-request-count TOPIC_REQUEST_COUNT
+                        number of requests to perform in random topic generation
+  --contextual-prompt-ratio CONTEXTUAL_PROMPT_RATIO
+                        ratio of prompts that should be contextual, e.g. summarization of an article
   --skip-instruction-re SKIP_INSTRUCTION_RE
                         regular expression used to filter low-quality/unusable instructions
-  --code-gen-re CODE_GEN_RE
-                        regular expression used to filter coding/programming tasks
-  --samples-per-request SAMPLES_PER_REQUEST
-                        number of random sample instructions to include in prompts
-  --min-instruction-length MIN_INSTRUCTION_LENGTH
-                        minimum instruction length
-  --max-instruction-length MAX_INSTRUCTION_LENGTH
-                        maximum instruction length
   --temperature TEMPERATURE
                         temperature parameter to use in OpenAI requests
   --top-p TOP_P         top-p parameter to use in OpenAI requests
@@ -81,10 +82,26 @@ options:
                         presence penalty to use in OpenAI requests
   --max-usage-tokens MAX_USAGE_TOKENS
                         Maximum token usage, calculated as sum of total_tokens from responses
-  --prompt-generation-concurrency PROMPT_GENERATION_CONCURRENCY
-                        Number of concurrent prompt generation threads/requests to use
+  --concurrency CONCURRENCY
+                        Number of concurrent threads/requests to use
   --min-docsearch-score MIN_DOCSEARCH_SCORE
+                        Minimum similarity score when querying vector DB to consider a prompt unique
 ```
+
+### Using custom topics:
+
+If you want to use a specific set of topics for prompt generation, add `--topics-path /path/to/topics.txt` to the command.  This file must be plain text, one topic per line.
+
+### Using a custom topic generator:
+
+If you want to use random topics, but want those topics to be somewhat related to a specific category or idea, try playing with `--topic-generation-prompt` (and probablyl `--topic-request-count`).  By default, the topic generation prompt is just random, but you can try things like:
+
+```
+... --topic-generation-prompt "Give me a list of 100 significant historical battles." --topic-request-count 10
+```
+
+Since the returned topics may include duplicates, it is not guaranteed that your topic list will contain 100 * 10 topics.
+
 
 ## Coming soon
 

--- a/airoboros/self_instruct.py
+++ b/airoboros/self_instruct.py
@@ -31,29 +31,41 @@ from langchain.embeddings import HuggingFaceEmbeddings
 
 # Defaults and constants.
 BATCH_SIZE = 13
-DEFAULT_PROMPT = f"""You are asked to generate a set of {BATCH_SIZE} diverse prompts.  These prompts will be given to a GPT model and we will evaluate the GPT model for completing the prompts.
+CONTEXTUAL_PROMPT = f"""Create a few instructions that can be provided to a GPT system to create text and a task related to the text.  Use diverse verbs, subject matters, and writing styles.
 
-Here are the requirements:
- * Try not to repeat the verb for each __instruction__ to maximize diversity.
+Examples:
+ * Generate a few paragraphs about the process of making damascus steel.
+ * Write a short story about a goat/bird chimera that enjoys sailing.
+ * Compose a news article about a breakthrough in tire technology.
+ * Give me a detailed description of the Battle of Rennell Island during World War II, along with key dates, locations, and people involved.
+
+Ensure each instruction is related to one of the following topics:
+{{topics}}
+
+Numbered list of {BATCH_SIZE} instructions:
+"""
+CONTEXT_TASK_INJECTION = "At the beginning of the text, add an instruction that can make use the text to respond.  This instruction type can be closed-context question answering, summarization, information extraction, etc."
+DEFAULT_PROMPT = f"""Create a set of {BATCH_SIZE} diverse instructions.
+
+Requirements for the instructions:
+ * Do not repeat the verb for each instruction to maximize diversity.
  * Try to avoid controversial and politically charged subjects.
- * The __instruction__ should include a variety of types of prompts, such as open-ended text generation, creative writing, brainstorming, classification, contextual question-answering, summarization, editing, information extraction, logical reasoning, etc.
- * The __instruction__ should be something a large language model can complete with a text response, for example do not create a task asking to create visual/audio output, setting an alarm, scheduling something on the calendar, etc. because the language model cannot perform those tasks.
- * The __instruction__ should be in English.
- * The __instruction__ should be between 1 and 3 sentences long.
- * For prompts that require extracting information from __passage__, e.g. question-answering, summarization, information extraction, etc., include a passage of text with 2-8 sentences in __passage__ providing all relevant data, including more information than necessary to generate __response__. __passage__ must not be simple placeholders or links to external resources.  Be sure to include all words, phrases, dates, or lists of items in __passage__ if those are part of __response__.
- * Not all prompts require __passage__. For example, when a task asks about some general information, e.g. "what is the highest peak in the world?", it is not necssary to provide a specific __passage__. In this case, we simply put "__no_context__" in the __passage__ field.
- * Each generated __response__ should be an appropriate response to the __instruction__.
- * Be sure to include {BATCH_SIZE} prompts in the response.
-REPLACE_TOPICS
+ * The list of instructions should include a variety of types of prompts, such as open-ended text generation, creative writing, brainstorming, classification, editing, logical reasoning, etc.
+ * Each instruction must be something a large language model can complete with a text response, for example do not create a task asking to create visual/audio output, setting an alarm, scheduling something on the calendar, etc. because the language model cannot perform those tasks.
+ * Each instruction should be in English, and be between 1 and 3 sentences long.
+ * Do not include any prompts that would require additional information, for example instructions to summarize or extract information from a passage of text.
+ * Any instruction referencing a list of objects, such as classifying a list of items, should include the list of items.
 
-List of {BATCH_SIZE} prompts:
+Ensure each instruction is related to one of the following topics:
+{{topics}}
+
+Numbered list of {BATCH_SIZE} prompts:
 """
 SKIP_WORDS = ["image", "graph", "picture", "file", "map", "draw", "plot", "go to"]
 SKIP_SEARCH_RE = re.compile(r"\b{'|'.join(SKIP_WORDS)}s?\b", re.I)
 CODE_GEN_RE = re.compile(
     r"^(?:write|generate|create)(?:a )?(?:\w+ )?(?:script|program|code)\W", re.I
 )
-DOLLY_SEED_URL = "https://storage.googleapis.com/airoboros-dump/databricks-dolly-15k.jsonl"
 OPENAI_API_BASE_URL = "https://api.openai.com"
 MODEL_ENDPOINTS = {
     "completions": [
@@ -96,13 +108,15 @@ class SelfInstructor:
             "default": 100000,
             "help": "number of instructions to generate, not including the seed instructions",
         },
-        "--seed-tasks-path": {
-            "type": str,
-            "help": "path to an input seed instructions JSONL file",
-        },
         "--output-path": {
             "type": str,
             "help": "path to store all generated instructions in",
+            "default": "instructions.jsonl",
+        },
+        "--topics-path": {
+            "type": str,
+            "help": "path to a newline separated list of topics",
+            "default": "topics.txt"
         },
         "--overwrite": {
             "action": "store_true",
@@ -115,7 +129,17 @@ class SelfInstructor:
         "--prompt": {
             "type": str,
             "default": DEFAULT_PROMPT,
-            "help": "prompt prefix to use for generating tasks",
+            "help": "prompt prefix to use for generating non-contextual instructions",
+        },
+        "--contextual-prompt": {
+            "type": str,
+            "default": CONTEXTUAL_PROMPT,
+            "help": "prompt to use for generating contextual prompts",
+        },
+        "--contextual-prompt-ratio": {
+            "type": float,
+            "default": 0.15,
+            "help": "ratio of prompts that should be contextual, e.g. summarization of an article",
         },
         "--skip-instruction-re": {
             "type": str,
@@ -127,24 +151,9 @@ class SelfInstructor:
             "default": CODE_GEN_RE.pattern,
             "help": "regular expression used to filter coding/programming tasks",
         },
-        "--samples-per-request": {
-            "type": str,
-            "default": 3,
-            "help": "number of random sample instructions to include in prompts",
-        },
-        "--min-instruction-length": {
-            "type": int,
-            "default": 2,
-            "help": "minimum instruction length",
-        },
-        "--max-instruction-length": {
-            "type": int,
-            "default": 150,
-            "help": "maximum instruction length",
-        },
         "--temperature": {
             "type": float,
-            "default": 0.7,
+            "default": 0.9,
             "help": "temperature parameter to use in OpenAI requests",
         },
         "--top-p": {
@@ -185,18 +194,15 @@ class SelfInstructor:
         organization_id: str = None,
         openai_api_key: str = None,
         instruction_count: int = 100000,
-        seed_tasks: List[Dict[str, str]] = None,
-        seed_tasks_path: str = None,
-        output_path: str = None,
+        output_path: str = "instructions.jsonl",
+        topics_path: str = "topics.txt",
         overwrite: bool = False,
         append: bool = True,
-        use_dolly_seed: bool = True,
         prompt: str = DEFAULT_PROMPT,
+        contextual_prompt: str = CONTEXTUAL_PROMPT,
+        contextual_prompt_ratio: float = 0.15,
         skip_instruction_re: re.Pattern = SKIP_SEARCH_RE,
         code_gen_re: re.Pattern = CODE_GEN_RE,
-        min_instruction_length: int = 3,
-        max_instruction_length: int = 150,
-        samples_per_request: int = 3,
         temperature: float = 0.7,
         top_p: float = 0.5,
         frequency_penalty: int = 0,
@@ -214,101 +220,58 @@ class SelfInstructor:
                 "OPENAI_API_KEY environment variable or openai_api_key must be provided"
             )
         self.instruction_count = instruction_count
-        if not output_path:
-            output_path = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)),
-                "output",
-                "instructions.jsonl",
-            )
-        self.output_path = output_path
+        self.output_path = os.path.abspath(output_path)
+        self.topics_path = os.path.abspath(topics_path)
         self.overwrite = overwrite
         self.append = append
-        output_dir = os.path.dirname(os.path.abspath(output_path))
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
         self.prompt = prompt
+        self.contextual_prompt = contextual_prompt
+        self.contextual_prompt_ratio = contextual_prompt_ratio
         self.skip_instruction_re = skip_instruction_re
         if isinstance(skip_instruction_re, str):
             self.skip_instruction_re = re.compile(skip_instruction_re, re.I)
         self.code_gen_re = code_gen_re
         if isinstance(code_gen_re, str):
             self.code_gen_re = re.compile(code_gen_re, re.I)
-        self.min_instruction_length = min_instruction_length
-        self.max_instruction_length = max_instruction_length
         self.temperature = temperature
         self.top_p = top_p
         self.frequency_penalty = frequency_penalty
         self.presence_penalty = presence_penalty
-        self.samples_per_request = samples_per_request
         self.max_usage_tokens = max_usage_tokens
-        self._validate_model()
-        self.machine_tasks = []
-        self._initialize_seed_tasks(seed_tasks, seed_tasks_path, use_dolly_seed)
+        self.validate_model()
         self.used_tokens = 0
         self.random_topics = set([])
         self.stop_producing = False
         self.prompt_generation_concurrency = prompt_generation_concurrency
         self.min_docsearch_score = min_docsearch_score
-        self._initialize_docstore()
+        self.initialize_docstores()
 
-    def _initialize_docstore(self):
-        """Initialize the in-memory vector database used to check prompt uniqueness."""
-        logger.info(
-            "Initializing in-memory document store for similarity comparison..."
-        )
-        texts = [
-            prompt["instruction"] for prompt in self.seed_tasks + self.machine_tasks
-        ]
-        self.docstore = Chroma.from_texts(texts, HuggingFaceEmbeddings())
-
-    def _initialize_seed_tasks(
-        self,
-        seed_tasks: List[Dict[str, str]],
-        seed_tasks_path: str,
-        use_dolly_seed: bool,
-    ):
-        """Helper method to construct the seed tasks, either as input dict, from
-        user-provided seed path, or using the dolly 15k seeds (default).
-        """
-        if seed_tasks:
-            self.seed_tasks = seed_tasks
-            return
-        if seed_tasks_path:
-            seed_tasks = []
-            with open(seed_tasks_path) as infile:
-                for line in infile.readlines():
-                    seed_tasks.append(json.loads(line))
-        elif use_dolly_seed:
-            dolly_seed_path = os.path.join(
-                os.path.dirname(os.path.abspath(__file__)), ".seed", "dolly_seeds.jsonl"
-            )
-            if not os.path.exists(os.path.dirname(dolly_seed_path)):
-                os.mkdir(os.path.dirname(dolly_seed_path))
-            if not os.path.isfile(dolly_seed_path):
-                result = requests.get(DOLLY_SEED_URL)
-                with open(dolly_seed_path, "w") as outfile:
-                    outfile.write(result.text)
-            with open(dolly_seed_path, "r") as infile:
-                seed_tasks = [json.loads(line) for line in infile.readlines()]
-            self.seed_tasks = seed_tasks
-        logger.info(f"Found {len(self.seed_tasks)} human seed tasks to use...")
+    def initialize_docstores(self):
+        """Initialize the in-memory vector databases used to check prompt uniqueness."""
+        self.machine_task_count = 0
+        docs = []
         if os.path.exists(self.output_path):
             if self.overwrite:
                 os.remove(self.output_path)
             elif self.append:
                 with open(self.output_path, "r") as infile:
-                    self.machine_tasks = [
-                        json.loads(line) for line in infile.readlines()
-                    ]
-                logger.info(
-                    f"Found {len(self.machine_tasks)} pre-existing machine seed tasks to use..."
-                )
+                    for line in infile.readlines():
+                        task = json.loads(line)
+                        self.machine_task_count += 1
+                        docs.append(task["instruction"])
+                logger.info(f"Found {self.machine_task_count} existing machine-generated instructions.")
             else:
-                raise RuntimeError(
-                    f"{self.output_path} already exists, but overwrite and append are false!"
-                )
+                raise RuntimeError(f"{self.output_path} already exists, but overwrite and append are false!")
+        logger.info(
+            "Initializing in-memory document store for similarity comparison..."
+        )
+        if not docs:
+            docs = ["__initialize__"]
+        embeddings = HuggingFaceEmbeddings()
+        self.docstore = Chroma.from_texts(texts, embeddings)
+        self.pending_docstore = Chroma.from_texts(["__initialize__"], embeddings)
 
-    def _validate_model(self):
+    def validate_model(self):
         """Ensure the specified model is available, and configure the endpoint
         to use accordingly (chat completions or completions).
         """
@@ -332,26 +295,9 @@ class SelfInstructor:
             raise ValueError(f"Model is not available to your API key: {self.model}")
         logger.success(f"Successfully validated model: {self.model}")
 
-    @staticmethod
-    def clean_instruction_text(instruction: str) -> str:
-        """Remove extra/trailing whitespace from instruction prompts.
-
-        :param instruction: The prompt text to clean.
-        :type instruction: str
-
-        :return: The cleaned prompt text.
-        :rtype: str
-        """
-        return re.sub(
-            r"\s+", " ", " ".join(instruction.splitlines()).strip().rstrip(":")
-        )
-
     def initialize_random_topics(self):
-        path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), ".seed", "topics.txt"
-        )
-        if os.path.exists(path):
-            with open(path, "r") as infile:
+        if os.path.exists(self.topics_path):
+            with open(self.topics_path, "r") as infile:
                 self.random_topics = {
                     line.strip().lower() for line in infile.readlines() if line.strip()
                 }
@@ -364,7 +310,7 @@ class SelfInstructor:
                 [
                     {
                         "model": "text-davinci-003",
-                        "prompt": ["Give me a list of 200 completely random topics."]
+                        "prompt": ["Give me a numbered list of 200 completely random topics."]
                         * 20,
                         "temperature": 1.0,
                         "max_tokens": 800,
@@ -372,7 +318,7 @@ class SelfInstructor:
                 ]
                 * 20,
             )
-        with open(path, "w") as outfile:
+        with open(self.topics_path, "w") as outfile:
             for response in responses:
                 if not response:
                     continue
@@ -386,133 +332,69 @@ class SelfInstructor:
             f"Successfully generated {len(self.random_topics)} random topics..."
         )
 
-    def generate_prompt_from_instructions(
-        self, instructions: List[Dict[str, any]]
-    ) -> str:
-        """Generate a single prompt string with multiple instructions.
+    def generate_prompt(self, template: str):
+        """Generate a single prompt, inserting random topics.
 
-        :param instructions: A list of instructions to encode.
-        :type instructions: List[str]
+        :param template: The prompt template to use.
+        :type template: str
 
-        :return: The encoded prompt.
+        :return: The prompt, including a list of random topics.
         :rtype: str
         """
-        topic_prompt = (
-            "* Ensure each generated prompt is related to one of the following topics: "
-        )
-        topic_texts = random.sample(list(self.random_topics), min(BATCH_SIZE, 6))
-        topic_prompt += ", ".join(topic_texts)
-        prompt = [self.prompt.replace("REPLACE_TOPICS", topic_prompt)]
-        for idx, instruction in enumerate(instructions):
-            text = self.clean_instruction_text(instruction["instruction"])
-            prompt.append(f"{idx + 1}. __instruction__: {text}")
-            context = (
-                "__no_context__"
-                if not instruction["context"].strip()
-                else instruction["context"].strip()
-            )
-            prompt.append(f"{idx + 1}. __passage__: {context}")
-            prompt.append(f"{idx + 1}. __response__: {instruction['response']}")
-            prompt.append("\n")
-        return "\n".join(prompt)
+        topics = "\n".join([
+            f" * {topic}"
+            for topic in random.sample(list(self.random_topics), min(BATCH_SIZE, 7))
+        ])
+        return template.format(topics=topics)
 
-    def extract_instructions_from_response(
-        self, response: Dict[str, Any]
-    ) -> List[Dict[str, Any]]:
+    def is_too_similar(self, instruction, docstore) -> bool:
+        """Check if the input instruction is too similar to an existing instruction.
+
+        :param instruction: The candidate instruction to check.
+        :type instruction: str
+
+        :param docstore: The docstore to perform similarity search against.
+        :type docstore: Chroma
+
+        :return: True if too similar, otherwise false.
+        :rtype: bool
+        """
+        for _, score in docstore.similarity_search_with_score(instruction, k=1):
+            if score < self.min_similarity_score:
+                return True
+        return False
+
+    def extract_instructions_from_response(self, text: str) -> List[str]:
         """Extract the list of instructions from the OpenAI response.
 
-        :param response: The response from the OpenAI request.
-        :type re: Dict[str, Any]
+        :param text: The OpenAI response text.
+        :type text: str
 
         :return: List of instructions.
         :rtype: List[str]
         """
-        if (
-            not response
-            or not response.get("choices")
-            or response["choices"][0]["finish_reason"] == "length"
-        ):
+        if not text:
             return []
-
-        text = None
-        if self._completions:
-            text = response["choices"][0]["text"]
-        else:
-            text = response["choices"][0]["message"]["content"]
-
-        tasks = []
-        for instruction in re.findall(
-            r"(\d+\s*\.\s*__instruction__:[\s\r\n]*.*?)(?=\d+\s*\.\s*__|$)",
-            text,
-            re.DOTALL,
-        ):
-            idx = instruction.split(".")[0].strip()
-            instruction_text = instruction.split("__instruction__:")[-1].strip()
-            if not instruction_text:
-                continue
-            if (
-                not self.min_instruction_length
-                < len(instruction_text.split())
-                < self.max_instruction_length
-            ):
-                logger.warning(
-                    f"Skipping instruction: {instruction_text} [instruction length]"
-                )
+        instructions = []
+        for instruction in re.findall(r"\s*\d+\s*\.\s(.*)\s*", text):
             # Skip various prompts that have been deemed unsuitable for language models
             # by the self-instruct team.
             if (
-                self.skip_instruction_re.search(instruction_text)
-                or self.code_gen_re.search(instruction_text)
-                or instruction_text[0] in string.punctuation
-                or not instruction_text[0].isascii()
+                self.skip_instruction_re.search(instruction)
+                or self.code_gen_re.search(instruction)
+                or instruction[0] in string.punctuation
+                or not instruction[0].isascii()
             ):
                 logger.warning(
-                    f"Skipping instruction: {instruction_text} [code, ascii, other unsuitable]"
+                    f"Skipping instruction: {instruction} [code, ascii, other unsuitable]"
                 )
                 continue
-            context = re.search(
-                f"(?<!\\d){idx}\\s*\\.\\s*__passage__:[\\r\\n\\s]*(.*?)(?=\\d+\\s*\\.\\s*__|$)",
-                text,
-                re.DOTALL,
-            )
-            if not context:
-                logger.warning(
-                    f"Skipping instruction: {instruction_text} [context not provided]"
-                )
-                continue
-            context = context.group(1).strip()
-            if context == "__no_context__":
-                context = ""
-            response = re.search(
-                f"(?<!\\d){idx}\\s*\\.\\s*__response__:[\\r\\n\\s]*(.*?)(?=\\d+\\s*\\.\\s*__|$)",
-                text,
-                re.DOTALL,
-            )
-            if not response or not response.group(1).strip():
-                logger.warning(
-                    f"Skipping instruction: {instruction_text} [response not provided]"
-                )
-                continue
-            response = response.group(1).strip()
-            if len(response) > len(context):
-                logger.warning("Ignoring context, shorter than response.")
-                context = ""
-            else:
-                scorer = rouge_scorer.RougeScorer(["rougeL"], use_stemmer=False)
-                if scorer.score(context, response)["rougeL"].fmeasure >= 0.7:
-                    logger.warning("Ignoring context, too similar to response.")
-                    context = ""
-            tasks.append(
-                {
-                    "instruction": instruction_text,
-                    "context": context,
-                    "response": response,
-                }
-            )
-            logger.info(
-                f"Generated candidate task [has context: {context != ''}]: {instruction_text}"
-            )
-        return tasks
+            if self.is_too_similar(self.docstore) or self.is_too_similar(self.pending_docstore):
+                logger.warning(f"Skipping instruction, too similar [{score}]: {instruction}")
+            self.pending_docstore.add_texts([instruction])
+            instructions.append(instruction)
+            logger.info(f"Generated candidate task: {instruction}")
+        return instruction
 
     @backoff.on_exception(
         backoff.expo,
@@ -578,18 +460,15 @@ class SelfInstructor:
             logger.error(f"Error performing post: {ex}")
         return None
 
-    def generate_instruction_batch(self, queue: Queue) -> None:
-        """Generate an set of instructions.
+    def generate_response(self, instruction: str) -> str:
+        """Call OpenAI with the specified instruction and return the text response.
 
-        :param queue: Queue to pass generated outputs to.
-        :type queue: Queue
+        :param instruction: The instruction to respond to.
+        :type instruction: str
+
+        :return: Response text.
+        :rtype: str
         """
-        instructions = random.sample(self.seed_tasks, self.samples_per_request)
-        prompt = self.generate_prompt_from_instructions(instructions)
-        estimated_tokens = int(len(prompt) / 4)
-        if estimated_tokens > 2700:
-            logger.warning("Skipping prompt, too long")
-            return
         path = "/v1/completions" if self._completions else "/v1/chat/completions"
         payload = {
             "model": self.model,
@@ -597,20 +476,46 @@ class SelfInstructor:
             "top_p": self.top_p,
             "frequency_penalty": self.frequency_penalty,
             "presence_penalty": self.presence_penalty,
-            "stop": [f"{BATCH_SIZE+1}."],
-            "max_tokens": 4000 - estimated_tokens if self._completions else None,
         }
         if self._completions:
-            payload["prompt"] = prompt
+            payload["prompt"] = instruction
+            payload["max_tokens"] = 4000
         else:
-            payload["messages"] = [{"role": "user", "content": prompt}]
-        try:
-            for new_instruction in self.extract_instructions_from_response(
-                self._post(path, payload)
+            payload["messages"] = [{"role": "user", "content": instruction}]
+        response = self._post_no_exc(path, payload)
+        if (
+                not response
+                or not response.get("choices")
+                or response["choices"][0]["finish_reason"] == "length"
             ):
-                queue.put(new_instruction)
-        except ContextLengthExceededError:
-            ...
+            return None
+        text = None
+        if self._completions:
+            text = response["choices"][0]["text"]
+        else:
+             text = response["choices"][0]["message"]["content"]
+        return text
+
+    def generate_instruction_batch(self, queue: Queue) -> None:
+        """Generate an set of instructions.
+
+        :param queue: Queue to pass generated outputs to.
+        :type queue: Queue
+        """
+        contextual = random.random() <= self.contextual_prompt_ratio
+        prompt = self.generate_prompt(self.prompt)
+        for new_instruction in self.extract_instructions_from_response(
+            self.generate_response(prompt)
+        ):
+            prompt = new_instruction
+            if contextual:
+                prompt = self.generate_response("  ".join([new_instruction, CONTEXT_TASK_INJECTION]))
+            if prompt:
+                response = self.generate_response(prompt)
+                if response:
+                    queue.put({"instruction": prompt, "response": response})
+                else:
+                    logger.error(f"Error generating response to: {prompt.splitlines()[0]}...")
 
     def generate_instruction_batches(self, queue: Queue) -> None:
         """Generate batches of instructions, storing new instructions in queue.
@@ -642,7 +547,7 @@ class SelfInstructor:
         :type queue: Queue
         """
         with open(self.output_path, "a+") as outfile:
-            while len(self.machine_tasks) < self.instruction_count or consume_remaining:
+            while self.machine_task_count < self.instruction_count or consume_remaining:
                 instruction = queue.get()
                 if not instruction:
                     break
@@ -659,22 +564,20 @@ class SelfInstructor:
                     continue
                 outfile.write(json.dumps(instruction) + "\n")
                 outfile.flush()
-                self.machine_tasks.append(instruction)
+                self.machine_task_count += 1
                 self.docstore.add_texts([instruction["instruction"]])
                 logger.success(
-                    f"Generated unique [score={similarity_score}] instruction [total={len(self.machine_tasks)}]: {instruction['instruction']}"
+                    f"Generated unique [score={similarity_score}] instruction [total={self.machine_task_count}]: {instruction['instruction']}"
                 )
         self.stop_producing = True
 
     def run(self):
         """Run the self-instruct, instruction generation task to completion."""
         self.initialize_random_topics()
-        if len(self.machine_tasks) >= self.instruction_count:
-            logger.error(
-                f"Already have {len(self.machine_tasks)} machine-generated tasks!"
-            )
+        if self.machine_task_count >= self.instruction_count:
+            logger.error("Already have {self.machine_task_count} machine-generated tasks!")
             return
-        queue = Queue(maxsize=100)
+        queue = Queue()
         producers = [
             threading.Thread(target=self.generate_instruction_batches, args=(queue,))
             for _ in range(self.prompt_generation_concurrency)
@@ -692,9 +595,8 @@ class SelfInstructor:
         # Consume any tasks generated after the consumer stopped.
         queue.put(None)
         self.validate_and_store_results(queue, consume_remaining=True)
-
         logger.success(
-            f"Finished generating {len(self.machine_tasks)} instructions and responses."
+            f"Finished generating {self.machine_task_count} instructions and responses."
         )
 
 

--- a/airoboros/self_instruct.py
+++ b/airoboros/self_instruct.py
@@ -513,7 +513,7 @@ class SelfInstructor:
         :param queue: Queue to pass generated outputs to.
         :type queue: Queue
         """
-        contextual = random.random() <= self.contextual_prompt_ratio or True
+        contextual = random.random() <= self.contextual_prompt_ratio
         prompt = self.generate_prompt(
             self.prompt if not contextual else self.contextual_prompt
         )
@@ -525,7 +525,6 @@ class SelfInstructor:
                 prompt = self.generate_response(
                     "  ".join([new_instruction, CONTEXT_TASK_INJECTION])
                 )
-                prompt = re.sub(r"^(\w+\s?){1,3}:\s+", "", prompt)
             if prompt:
                 response = self.generate_response(prompt)
                 if response:

--- a/airoboros/self_instruct.py
+++ b/airoboros/self_instruct.py
@@ -536,7 +536,7 @@ class SelfInstructor:
                         + f"\n\nUsing the text above, respond to the instruction: {parts[1]}"
                     )
                 else:
-                    prompt = parts[1] + f"\n\nContext:\n\n{parts[0]}"
+                    prompt = parts[1] + f"\n\nContext:\n{parts[0]}"
             queue.put({"instruction": prompt})
 
     def generate_instruction_batches(self, queue: Queue) -> None:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     license="Apache 2.0",
     packages=["airoboros"],
     install_requires=[
-        "rouge-score>=0.1.2",
         "aiohttp>=3.8",
         "backoff>=2.2",
         "requests>=2.28",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md"))
 
 setup(
     name="airoboros",
-    version="0.0.7",
+    version="0.1.0",
     description="Updated and improved implementation of the self-instruct system.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -30,7 +30,7 @@ setup(
         ],
     },
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md"))
 
 setup(
     name="airoboros",
-    version="0.0.6",
+    version="0.0.7",
     description="Updated and improved implementation of the self-instruct system.",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -21,7 +21,7 @@ setup(
         "requests>=2.28",
         "loguru>=0.7",
         "chromadb>=0.3.21",
-        "langchain>=0.0.155",
+        "langchain>=0.0.162",
         "sentence-transformers>=2.2.2",
     ],
     extras_require={


### PR DESCRIPTION
* Rewrite prompts to allow more diversity from openai models.
* Use two-phase mechanism for contextual prompt generation, i.e. create a writing prompt, then call openai with that prompt to generate text and an instruction related to the text.
* Get the responses separately, otherwise the output is far too concise and pointed to be useful.
* Support for custom topics as input file.
* Support for custom topic generation prompt, which allows category specific model fine-tuning.
* Configurable batch size.
* Better concurrency/queue management.